### PR TITLE
Channel switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
   "author": "Michiel",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.5.1",
-    "fluent-ffmpeg": "^2.1.2",
     "@discordjs/opus": "^0.3.2",
-    "protobufjs": "^6.8.6"
+    "bluebird": "^3.7.2",
+    "fluent-ffmpeg": "^2.1.2",
+    "protobufjs": "^6.9.0"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "gulp": "^3.9.1",
-    "istanbul": "^0.4.5",
-    "jsdoc-to-markdown": "^4.0.1",
-    "mocha": "^5.1.1"
+    "chai": "^4.2.0",
+    "gulp": "^4.0.2",
+    "nyc": "^15.1.0",
+    "jsdoc-to-markdown": "^6.0.1",
+    "mocha": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "fluent-ffmpeg": "^2.1.2",
-    "node-opus": "^0.3.0",
+    "@discordjs/opus": "^0.3.2",
     "protobufjs": "^6.8.6"
   },
   "devDependencies": {

--- a/src/Client.js
+++ b/src/Client.js
@@ -117,6 +117,19 @@ class Client extends EventEmitter {
         return this.user.channel.sendMessage(message, recursive)
     }
 
+    /**
+     * Switches to another channel
+     * @param  {Number} id         The id of the channel to switch to
+     * @return {Promise<>}
+     */
+    switchChannel(id) {
+        if (this.channels.has(id)) {
+            return this.connection.writeProto('UserState', {session: this.user.session, actor: this.user.session , channelId: id})
+        } else {
+            return Promise.reject('ChannelId unknown')
+        }
+    }
+
     mute() {
         this.connection.writeProto('UserState', {session: this.user.session, actor: this.user.session , selfMute: true})
     }

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -72,7 +72,7 @@ class Connection extends EventEmitter {
     }
 
     _writeHeader(type, data) {
-        const header = new Buffer(6)
+        const header = Buffer.alloc(6)
         header.writeUInt16BE(type, 0)
         header.writeUInt32BE(data, 2)
         this._writePacket(header)
@@ -102,7 +102,7 @@ class Connection extends EventEmitter {
 
         const sequenceVarint = Util.toVarint(voiceSequence)
 
-        const voiceHeader = new Buffer(1 + sequenceVarint.length)
+        const voiceHeader = Buffer.alloc(1 + sequenceVarint.length)
         voiceHeader[0] = typeTarget
         sequenceVarint.value.copy(voiceHeader, 1, 0)
         let header
@@ -122,7 +122,7 @@ class Connection extends EventEmitter {
             throw new TypeError('Celt is not supported')
         }
 
-        const frame = new Buffer(header.length + packet.length)
+        const frame = Buffer.alloc(header.length + packet.length)
         header.copy(frame, 0)
 
         packet.copy(frame, header.length)

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -2,7 +2,7 @@ const tls = require('tls');
 const Protobuf = require('./Protobuf')
 const Promise = require('bluebird')
 const EventEmitter = require('events').EventEmitter
-const OpusEncoder = require('node-opus').OpusEncoder
+const OpusEncoder = require('@discordjs/opus').OpusEncoder
 const Constants = require('./Constants')
 const Util = require('./Util')
 
@@ -11,7 +11,7 @@ class Connection extends EventEmitter {
         super()
 
         this.options = options;
-        this.opusEncoder = new OpusEncoder(Constants.sampleRate)
+        this.opusEncoder = new OpusEncoder(Constants.sampleRate, 1)
         this.currentEncoder = this.opusEncoder
         this.codec = Connection.codec().Opus
         this.voiceSequence = 0

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -11,7 +11,7 @@ class Connection extends EventEmitter {
         super()
 
         this.options = options;
-        this.opusEncoder = new OpusEncoder(Constants.sampleRate, 1)
+        this.opusEncoder = new OpusEncoder(Constants.Audio.sampleRate, 1)
         this.currentEncoder = this.opusEncoder
         this.codec = Connection.codec().Opus
         this.voiceSequence = 0

--- a/src/Util.js
+++ b/src/Util.js
@@ -7,7 +7,7 @@ class Util {
         var arr = [];
         if( i < 0 ) {
             i = ~i;
-            if( i <= 0x3 ) { return new Buffer([ 0xFC | i ]); }
+            if( i <= 0x3 ) { return Buffer.from([ 0xFC | i ]); }
 
             arr.push( 0xF8 );
         }
@@ -37,7 +37,7 @@ class Util {
         }
 
         return {
-            value: new Buffer( arr ),
+            value: Buffer.from( arr ),
             length: arr.length
         };
     }

--- a/src/voice/DispatchStream.js
+++ b/src/voice/DispatchStream.js
@@ -51,7 +51,7 @@ class DispatchStream extends WritableStream {
     }
 
     _createFrameBuffer() {
-        return new Buffer(Constants.Audio.frameSize * 2)
+        return Buffer.alloc(Constants.Audio.frameSize * 2)
     }
 
     _processAudioBuffer() {


### PR DESCRIPTION
Some fixes from @jsjb (Update deps, switch from `node-opus` to `@discordjs/opus`, fix buffer warnings) and add a new method to the client to be able to switch channels.

@Gielert : Feel free to cherry-pick only the last commit if you do not want to check the others. Would be nice though :)

Example how to switch channels: 
```javascript
client.on('ready', info => {
  console.log('Connected to Mumble server:', info);
  console.log('===== Channels: =====\n', client.channels);
  console.log('=====');

  // Find the correct channel and switch if found
  for (var [key, value] of client.channels) {
    console.log(key + " = ", value.name);
    if (value.name === 'MyBelovedChannel') {
      console.log('Switching :)');
      client.switchChannel(key);
    }
  }
});
```