### PR TITLE
Bump reported client version to 1.3 to fix server not reporting all channels

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -42,7 +42,7 @@ class Client extends EventEmitter {
 
         this.connection.on('connected', () => {
             this.connection.writeProto('Version', {
-                version: Util.encodeVersion(1, 0, 0),
+                version: Util.encodeVersion(1, 3, 0),
                 release: 'NoodleJS Client',
                 os: 'NodeJS',
                 os_version: process.version


### PR DESCRIPTION
I haven't dug into the mumble source to figure out exactly why, but it looks like the server alters its behavior based on the client version. In the case of #10, it wasn't sending ChannelState messages for all channels. This causes an exception while processing the ChannelState messages that *are* received in the event that one such missing channel is the parent of another channel.

Changing the reported client version from 1.0.0 to 1.3.0 solves this issue and seems reasonably recent enough to be a good target. On the other hand, I don't know where else the server may be varying its behavior according to client version, so this may also change behavior beyond just fixing #10.